### PR TITLE
17 add help flag

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -48,15 +48,15 @@ func ParseFlags() CLIFlags {
 
 	// Add custom usage message
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage of Health Data Printer:\n")
-		fmt.Fprintf(os.Stderr, "  health-printer [options]\n\n")
+		fmt.Fprintf(os.Stderr, "Usage of Health Fitness Data Printer:\n")
+		fmt.Fprintf(os.Stderr, "  fitness [options]\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
-		fmt.Fprintf(os.Stderr, "  health-printer -n 10 -c                    # Show 10 items in compact mode\n")
-		fmt.Fprintf(os.Stderr, "  health-printer -f name -v \"Pool Swim\"      # Show only Pool Swim workouts\n")
-		fmt.Fprintf(os.Stderr, "  health-printer -sort duration -desc        # Sort by duration descending\n")
-		fmt.Fprintf(os.Stderr, "  health-printer -i \"name,duration,distance\" # Show only specific fields\n")
+		fmt.Fprintf(os.Stderr, "  fitness -n 10 -c                    # Show 10 items in compact mode\n")
+		fmt.Fprintf(os.Stderr, "  fitness -f name -v \"Pool Swim\"      # Show only Pool Swim workouts\n")
+		fmt.Fprintf(os.Stderr, "  fitness -sort duration -desc        # Sort by duration descending\n")
+		fmt.Fprintf(os.Stderr, "  fitness -i \"name,duration,distance\" # Show only specific fields\n")
 	}
 
 	flag.Parse()

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -57,6 +57,7 @@ func ParseFlags() CLIFlags {
 		fmt.Fprintf(os.Stderr, "  fitness -f name -v \"Pool Swim\"      # Show only Pool Swim workouts\n")
 		fmt.Fprintf(os.Stderr, "  fitness -sort duration -desc        # Sort by duration descending\n")
 		fmt.Fprintf(os.Stderr, "  fitness -i \"name,duration,distance\" # Show only specific fields\n")
+		fmt.Println()
 	}
 
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -10,12 +10,12 @@ import (
 )
 
 func main() {
+	fmt.Println()
 	flags := cli.ParseFlags()
 	opts := cli.CreatePrintOptions(flags)
 
 	// Import data
 	data.ImportData()
-	fmt.Println()
 
 	// Determine which data to display
 	var err error
@@ -33,4 +33,5 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	fmt.Println()
 }


### PR DESCRIPTION
help flag added

Usage of Health Fitness Data Printer:
  fitness [options]

Options:
  -c    Use compact display mode
  -desc
        Sort in descending order
  -f string
        Filter type (name, distance, duration, energy)
  -i string
        Include only specific fields (comma-separated)
  -n int
        Maximum number of items to display (0 for all)
  -sort string
        Sort by field (name, date, duration, distance, energy)
  -time-format string
        Time format string (default "2006-01-02 15:04:05")
  -type string
        Data type to display (workouts or metrics) (default "workouts")
  -v string
        Filter value
  -x string
        Exclude specific fields (comma-separated)

Examples:
  fitness -n 10 -c                    # Show 10 items in compact mode
  fitness -f name -v "Pool Swim"      # Show only Pool Swim workouts
  fitness -sort duration -desc        # Sort by duration descending
  fitness -i "name,duration,distance" # Show only specific fields